### PR TITLE
Allow parent links on mobile menu

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -62,10 +62,11 @@ jQuery(function($) {
 		label: '<i class="fa fa-bars"></i>',
 		prependTo: '.mobile-nav',
 		closedSymbol: '&#43;',
-		openedSymbol: '&#45;'
+		openedSymbol: '&#45;',
+		allowParentLinks: true
 	});
 	$('.info-close').click(function(){
 		$(this).parent().fadeOut();
 		return false;
 	});
-});	
+});


### PR DESCRIPTION
Most menus with sub-menus have the parent item as a page. In mobile
mode we should be able to click on the parent item link.