### PR TITLE
Fix around font icons on customizer.

### DIFF
--- a/css/customizer.css
+++ b/css/customizer.css
@@ -12,6 +12,7 @@
   content: '\f10c';
   margin-right: 5px;
   color: #70787E;
+  float: left;
 }
 #accordion-section-amadeus_general h3:before {
   content: '\f013';

--- a/functions.php
+++ b/functions.php
@@ -182,6 +182,8 @@ function amadeus_customizer_styles() {
 
 	wp_enqueue_style( 'amadeus-customizer-styles', get_template_directory_uri() . '/css/customizer.css' );
 
+	wp_enqueue_style( 'amadeus-font-awesome', get_template_directory_uri() . '/fonts/font-awesome.min.css' );
+
 }
 add_action( 'customize_controls_print_styles', 'amadeus_customizer_styles' );
 


### PR DESCRIPTION
For 2nd commit, I fixed this:
![_2016_04_12_19_31](https://cloud.githubusercontent.com/assets/1886443/14457486/bd8b2dca-00e5-11e6-96ff-67373930ebd7.png)
